### PR TITLE
issue with document.h since merge

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -19,6 +19,7 @@
 #include "internal/meta.h"
 
 #include <memory>
+#include <limits>
 
 #if RAPIDJSON_HAS_CXX11
 #include <type_traits>
@@ -433,7 +434,7 @@ namespace internal {
 template<typename T, typename A>
 inline T* Realloc(A& a, T* old_p, size_t old_n, size_t new_n)
 {
-    RAPIDJSON_NOEXCEPT_ASSERT(old_n <= SIZE_MAX / sizeof(T) && new_n <= SIZE_MAX / sizeof(T));
+    RAPIDJSON_NOEXCEPT_ASSERT(old_n <= std::numeric_limits<size_t>::max() / sizeof(T) && new_n <= std::numeric_limits<size_t>::max() / sizeof(T));
     return static_cast<T*>(a.Realloc(old_p, old_n * sizeof(T), new_n * sizeof(T)));
 }
 

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -58,11 +58,11 @@ inline int CountDecimalDigit32(uint32_t n) {
 }
 
 inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buffer, int* len, int* K) {
-    static const uint64_t kPow10[] = { 1U, 10U, 100U, 1000U, 10000U, 100000U, 1000000U, 10000000U, 100000000U,
-                                       1000000000U, 10000000000U, 100000000000U, 1000000000000U,
-                                       10000000000000U, 100000000000000U, 1000000000000000U,
-                                       10000000000000000U, 100000000000000000U, 1000000000000000000U,
-                                       10000000000000000000U };
+    static const uint64_t kPow10[] = { 1ULL, 10ULL, 100ULL, 1000ULL, 10000ULL, 100000ULL, 1000000ULL, 10000000ULL, 100000000ULL,
+                                       1000000000ULL, 10000000000ULL, 100000000000ULL, 1000000000000ULL,
+                                       10000000000000ULL, 100000000000000ULL, 1000000000000000ULL,
+                                       10000000000000000ULL, 100000000000000000ULL, 1000000000000000000ULL,
+                                       10000000000000000000ULL };
     const DiyFp one(uint64_t(1) << -Mp.e, Mp.e);
     const DiyFp wp_w = Mp - W;
     uint32_t p1 = static_cast<uint32_t>(Mp.f >> -one.e);


### PR DESCRIPTION
Warnings in include/reader.h removed by by adding

 typedef typename InputStream::Ch Ch;
 
 to the other NumberStream classes that do not have it.

Issue resolved by modifying include/document.h as follows: adding space before, as in < :: and space before closing >

#ifndef RAPIDJSON_DEFAULT_ALLOCATOR
#define RAPIDJSON_DEFAULT_ALLOCATOR ::RAPIDJSON_NAMESPACE::MemoryPoolAllocator< ::RAPIDJSON_NAMESPACE::CrtAllocator >
#endif

and for my compiler gcc version:(gcc (GCC) 3.3.1 (SuSE Linux)  
I had to comment out __thread static

#elif defined(__GNUC__) || defined(__clang__)
            // This will generate -Wexit-time-destructors in clang, but that's
            // better than having under-alignment.
            //__thread static GenericValue buffer;
            static GenericValue buffer;

I am not sure what macro defines I need to use to force the else case, which uses  static GenericValue buffer;

===================================================================

Below is what I used in testing.

cd rapidjson-master
g++ -Wall -m32 -ggdb -Iinclude -O1 ./example/simpledom/simpledom.cpp -o simpledom 2>&1 | tee out.txt

Error when compiling simpledom.cpp

In file included from ./example/simpledom/simpledom.cpp:4:
include/rapidjson/document.h:667: error: ‘<::’ cannot begin a template-argument list
include/rapidjson/document.h:667: note: ‘<:’ is an alternate spelling for ‘[’. Insert whitespace between ‘<’ and ‘::’
include/rapidjson/document.h:667: note: (if you use -fpermissive G++ will accept your code)
include/rapidjson/document.h: In member function ‘rapidjson::GenericValue<Encoding, Allocator>& rapidjson::GenericValue<Encoding, Allocator>::operator[](const rapidjson::GenericValue<Encoding, SourceAllocator>&)’:
include/rapidjson/document.h:1247: error: ‘__thread’ before ‘static’
include/rapidjson/document.h: At global scope:
include/rapidjson/document.h:2498: error: ‘<::’ cannot begin a template-argument list
include/rapidjson/document.h:2498: note: ‘<:’ is an alternate spelling for ‘[’. Insert whitespace between ‘<’ and ‘::’

cd rapidjson-master
g++ -fpermissive -Wall -m32 -ggdb -Iinclude -O1 ./example/simpledom/simpledom.cpp -o simpledom 2>&1 | tee out.txt

This allowed me to build a working executable.

But with new rapidjson-master.zip drop from August 31, 2022, I now get this error instead, whether I use -fpermissive compiler flag or not:

In file included from include/rapidjson/document.h:20,
                 from example/simpledom/simpledom.cpp:4:
include/rapidjson/reader.h:1438: warning: lookup of `Ch' finds `typedef
   typename SourceEncoding::Ch rapidjson::GenericReader<SourceEncoding,
   TargetEncoding, StackAllocator>::Ch'
include/rapidjson/reader.h:1438: warning:   instead of `
   rapidjson::GenericReader<SourceEncoding, TargetEncoding,
   StackAllocator>::NumberStream<InputStream, StackCharacter, true, false>::Ch'
   from dependent base class
include/rapidjson/reader.h:1438: warning:   (use `typename NumberStream::Ch' if
   that's what you meant)
include/rapidjson/reader.h:1464: warning: lookup of `Ch' finds `typedef
   typename SourceEncoding::Ch rapidjson::GenericReader<SourceEncoding,
   TargetEncoding, StackAllocator>::Ch'
include/rapidjson/reader.h:1464: warning:   instead of `
   rapidjson::GenericReader<SourceEncoding, TargetEncoding,
   StackAllocator>::NumberStream<InputStream, StackCharacter, true, true>::Ch'
   from dependent base class
include/rapidjson/reader.h:1464: warning:   (use `typename NumberStream::Ch' if
   that's what you meant)
In file included from example/simpledom/simpledom.cpp:4:
include/rapidjson/document.h:667: error: parse error before `[' token
include/rapidjson/document.h:672: error: template declaration of `typedef
   Encoding rapidjson::EncodingType'
include/rapidjson/document.h:672: confused by earlier errors, bailing out

I can remove warnings in reader.h by adding

 typedef typename InputStream::Ch Ch;
 
 to the other NumberStream classes that do not have it.
 